### PR TITLE
[SEC-1362] Allow user to set their cert IP instead of detecting

### DIFF
--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -447,7 +447,8 @@ def bless(region, nocache, showgui, hostname, bless_config):
     userIP = UserIP(
         bless_cache=bless_cache,
         maxcachetime=bless_lambda_config['ipcachelifetime'],
-        ip_urls=bless_config.get_client_config()['ip_urls'])
+        ip_urls=bless_config.get_client_config()['ip_urls'],
+        fixed_ip=os.getenv('BLESSFIXEDIP', False))
 
     # Check if we can skip asking for MFA code
     if nocache is not True:

--- a/blessclient/user_ip.py
+++ b/blessclient/user_ip.py
@@ -6,12 +6,15 @@ from urllib2 import urlopen
 
 class UserIP(object):
 
-    def __init__(self, bless_cache, maxcachetime, ip_urls):
+    def __init__(self, bless_cache, maxcachetime, ip_urls, fixed_ip=False):
         self.fresh = False
         self.currentIP = None
         self.cache = bless_cache
         self.maxcachetime = maxcachetime
         self.ip_urls = ip_urls
+        if fixed_ip:
+            self.currentIP = fixed_ip
+            self.fresh = True
 
     def getIP(self):
         if self.fresh and self.currentIP:

--- a/tests/blessclient/user_ip_test.py
+++ b/tests/blessclient/user_ip_test.py
@@ -12,6 +12,11 @@ def test_getIP_fresh():
     assert user_ip.getIP() == '1.1.1.1'
 
 
+def test_fixed_ip():
+    user_ip = UserIP(None, 10, IP_URLS, '1.2.3.4')
+    assert user_ip.getIP() == '1.2.3.4'
+
+
 def test_getIP_cached():
     bc = BlessCache(None, None, BlessCache.CACHEMODE_ENABLED)
     bc.cache = {}


### PR DESCRIPTION
In some cases (like tethering on AT&T as of the past few days), the external IP used for http traffic is different from the external IP used for ssh. So allow the user to set their IP to a known value using the BLESSFIXEDIP environment variable.