### PR TITLE
[HOTFIX] Add my_ip to 'bastion' list

### DIFF
--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -537,11 +537,12 @@ def bless(region, nocache, showgui, hostname, bless_config):
             'Refusing to bless {}. Probably not an identity file.'.format(identity_file))
 
     my_ip = userIP.getIP()
+    ip_list = "{},{}".format(my_ip, bless_config.get_aws_config()['bastion_ips'])
     payload = {
         'bastion_user': username,
         'bastion_user_ip': my_ip,
         'remote_usernames': username,
-        'bastion_ips': bless_config.get_aws_config()['bastion_ips'],
+        'bastion_ips': ip_list,
         'command': '*',
         'public_key_to_sign': public_key,
     }


### PR DESCRIPTION
I missed that upstream took out the user's IP when issuing certificates, i.e., the change to bless/aws_lambda/bless_lambda.py in https://github.com/Netflix/bless/commit/bc6b3bfa4d41080fc03263d879888e8188959812. So blessclient needs to add that in, so that the user's source IP is allowed on the bastion server.