### PR TITLE
Allow remote user to be specified

### DIFF
--- a/blessclient.cfg.sample
+++ b/blessclient.cfg.sample
@@ -18,6 +18,9 @@ kms_service_name: bless-production
 # the internal IP of each should be listed here.
 bastion_ips: 10.100.1.230,192.168.200.0/24
 
+# remote_user: The remote username to authorize for SSH within the certificate. 
+# Defaults to the AWS user requesting the certificate
+
 [CLIENT]
 # domain_regex: A (python) regex that is tested by the blessclient to determine if we need
 # to run bless and get a certificate, or if we can skip it. This prevents blessclient from

--- a/blessclient/bless_config.py
+++ b/blessclient/bless_config.py
@@ -6,6 +6,7 @@ class BlessConfig(object):
     DEFAULT_CONFIG = {
         'user_session_length': '64800',
         'usebless_role_session_length': '3600',
+        'remote_user': None,
     }
 
     def __init__(self):
@@ -51,7 +52,8 @@ class BlessConfig(object):
                 }
             },
             'AWS_CONFIG': {
-                'bastion_ips': config.get('MAIN', 'bastion_ips')
+                'bastion_ips': config.get('MAIN', 'bastion_ips'),
+                'remote_user': config.get('MAIN', 'remote_user')
             },
             'REGION_ALIAS': {}
         }

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -540,10 +540,13 @@ def bless(region, nocache, showgui, hostname, bless_config):
 
     my_ip = userIP.getIP()
     ip_list = "{},{}".format(my_ip, bless_config.get_aws_config()['bastion_ips'])
+    remote_user = bless_config.get_aws_config()['remote_user']
+    if remote_user is None:
+        remote_user = username
     payload = {
         'bastion_user': username,
         'bastion_user_ip': my_ip,
-        'remote_usernames': username,
+        'remote_usernames': remote_user,
         'bastion_ips': ip_list,
         'command': '*',
         'public_key_to_sign': public_key,

--- a/tests/blessclient/bless_config_test.py
+++ b/tests/blessclient/bless_config_test.py
@@ -8,6 +8,7 @@ TEST_CONFIG = """
 region_aliases: iad, SFO
 kms_service_name: bless-production
 bastion_ips: 10.0.0.0/8,192.168.192.1
+remote_user: foo
 
 [CLIENT]
 domain_regex: (i-.*|.*\.example\.com|\A10\.0(?:\.[0-9]{1,3}){2}\Z)$
@@ -97,7 +98,8 @@ def test_load_config():
             'accountid': '111111111111'
         },
         'AWS_CONFIG': {
-            'bastion_ips': '10.0.0.0/8,192.168.192.1'
+            'bastion_ips': '10.0.0.0/8,192.168.192.1',
+            'remote_user': 'foo'
         },
         'CLIENT_CONFIG': {
             'domain_regex': '(i-.*|.*\\.example\\.com|\\A10\\.0(?:\\.[0-9]{1,3}){2}\\Z)$',
@@ -126,6 +128,7 @@ def test_get_configs(bless_config_test):
     assert 'functionname' in lambda_config
     aws_config = bless_config_test.get_aws_config()
     assert 'bastion_ips' in aws_config
+    assert 'remote_user' in aws_config
 
 
 def test_set_lambda_config(bless_config_test):


### PR DESCRIPTION
Right now I dont have a way to specify a remote username to SSH as (such as `ec2-user`). This allows that and falls back safely to the current default, the IAM user requesting the certificate to be signed.