### PR TITLE
Allow user to disable automatic loading of keys into running ssh-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .coverage
 .cache
+.DS_Store
 coverage.xml
 venv/
 blessclient.run

--- a/blessclient.cfg.sample
+++ b/blessclient.cfg.sample
@@ -55,10 +55,10 @@ update_script: update_blessclient.sh
 # tokens for when the user assumes the role necessary to call the BLESS Lambda. The default
 # is 3600 seconds (1 hour). The value must be in the range 900-3600.
 
-# update_sshagent: Specifies whether the identify key should be automatically added to the 
+# update_sshagent: Specifies whether the identity key should be automatically added to the
 running ssh-agent. If this option is set to 'true', the key and the ssh certificate retrieved
 from lambda are added to the agent. If this option is set to 'false', the key is not added
-to the agent.
+to the agent. The default is 'true'.
 
 [LAMBDA]
 # user_role: IAM Role that the user will assume, in order to run the BLESS Lambda. This

--- a/blessclient.cfg.sample
+++ b/blessclient.cfg.sample
@@ -55,6 +55,11 @@ update_script: update_blessclient.sh
 # tokens for when the user assumes the role necessary to call the BLESS Lambda. The default
 # is 3600 seconds (1 hour). The value must be in the range 900-3600.
 
+# update_sshagent: Specifies whether the identify key should be automatically added to the 
+running ssh-agent. If this option is set to 'true', the key and the ssh certificate retrieved
+from lambda are added to the agent. If this option is set to 'false', the key is not added
+to the agent.
+
 [LAMBDA]
 # user_role: IAM Role that the user will assume, in order to run the BLESS Lambda. This
 # role should be in the same AWS account as your Lambda.

--- a/blessclient/bless_config.py
+++ b/blessclient/bless_config.py
@@ -6,6 +6,7 @@ class BlessConfig(object):
     DEFAULT_CONFIG = {
         'user_session_length': '64800',
         'usebless_role_session_length': '3600',
+        'update_sshagent': 'true',
     }
 
     def __init__(self):
@@ -22,6 +23,13 @@ class BlessConfig(object):
             'awsregion': config.get(section, 'awsregion')
         }
 
+    def _strtobool(self, config):
+        if str(config).lower() in ("y", "yes", "true", "on", "1"):
+            return True
+        if str(config).lower() in ("n", "no", "false", "off", "0"):
+            return False
+        raise ValueError('Unexpected value: {}'.format(config))
+
     def parse_config_file(self, config_file):
         config = ConfigParser.SafeConfigParser(self.DEFAULT_CONFIG)
         loaded = config.readfp(config_file)
@@ -37,6 +45,7 @@ class BlessConfig(object):
                 'update_script': config.get('CLIENT', 'update_script'),
                 'user_session_length': int(config.get('CLIENT', 'user_session_length')),
                 'usebless_role_session_length': int(config.get('CLIENT', 'usebless_role_session_length')),
+                'update_sshagent': bool(self._strtobool(config.get('CLIENT', 'update_sshagent'))),
             },
             'BLESS_CONFIG': {
                 'userrole': config.get('LAMBDA', 'user_role'),

--- a/blessclient/bless_config.py
+++ b/blessclient/bless_config.py
@@ -23,13 +23,6 @@ class BlessConfig(object):
             'awsregion': config.get(section, 'awsregion')
         }
 
-    def _strtobool(self, config):
-        if str(config).lower() in ("y", "yes", "true", "on", "1"):
-            return True
-        if str(config).lower() in ("n", "no", "false", "off", "0"):
-            return False
-        raise ValueError('Unexpected value: {}'.format(config))
-
     def parse_config_file(self, config_file):
         config = ConfigParser.SafeConfigParser(self.DEFAULT_CONFIG)
         loaded = config.readfp(config_file)
@@ -45,7 +38,7 @@ class BlessConfig(object):
                 'update_script': config.get('CLIENT', 'update_script'),
                 'user_session_length': int(config.get('CLIENT', 'user_session_length')),
                 'usebless_role_session_length': int(config.get('CLIENT', 'usebless_role_session_length')),
-                'update_sshagent': bool(self._strtobool(config.get('CLIENT', 'update_sshagent'))),
+                'update_sshagent': config.getboolean('CLIENT', 'update_sshagent'),
             },
             'BLESS_CONFIG': {
                 'userrole': config.get('LAMBDA', 'user_role'),

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -578,11 +578,12 @@ def bless(region, nocache, showgui, hostname, bless_config):
         raise LambdaInvocationException(
             'BLESS client did not recieve a valid cert. Instead got: {}'.format(cert))
 
+    with open(cert_file, 'w') as cert_file:
+        cert_file.write(cert)
+
     # Check if we can skip adding identity into the running ssh-agent
     if bless_config.get_client_config()['update_sshagent'] is True:
         ssh_agent_remove_bless(identity_file)
-        with open(cert_file, 'w') as cert_file:
-            cert_file.write(cert)
         ssh_agent_add_bless(identity_file)
     else:
         logging.info(

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -578,12 +578,13 @@ def bless(region, nocache, showgui, hostname, bless_config):
         raise LambdaInvocationException(
             'BLESS client did not recieve a valid cert. Instead got: {}'.format(cert))
 
+    # Remove RSA identity from ssh-agent (if it exists)
+    ssh_agent_remove_bless(identity_file)
     with open(cert_file, 'w') as cert_file:
         cert_file.write(cert)
 
     # Check if we can skip adding identity into the running ssh-agent
     if bless_config.get_client_config()['update_sshagent'] is True:
-        ssh_agent_remove_bless(identity_file)
         ssh_agent_add_bless(identity_file)
     else:
         logging.info(

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -578,10 +578,16 @@ def bless(region, nocache, showgui, hostname, bless_config):
         raise LambdaInvocationException(
             'BLESS client did not recieve a valid cert. Instead got: {}'.format(cert))
 
-    ssh_agent_remove_bless(identity_file)
-    with open(cert_file, 'w') as cert_file:
-        cert_file.write(cert)
-    ssh_agent_add_bless(identity_file)
+    # Check if we can skip adding identity into the running ssh-agent
+    if bless_config.get_client_config()['update_sshagent'] is True:
+        ssh_agent_remove_bless(identity_file)
+        with open(cert_file, 'w') as cert_file:
+            cert_file.write(cert)
+        ssh_agent_add_bless(identity_file)
+    else:
+        logging.info(
+            "Skipping loading identity into the running ssh-agent "
+            'because this was disabled in the blessclient config.' )
 
     bless_cache.set('certip', my_ip)
     bless_cache.save()

--- a/tests/blessclient/bless_config_test.py
+++ b/tests/blessclient/bless_config_test.py
@@ -18,6 +18,7 @@ mfa_cache_file: token_cache.json
 ip_urls: http://checkip.amazonaws.com, http://api.ipify.org
 update_script: autoupdate.sh
 user_session_length: 3600
+update_sshagent: false
 
 [LAMBDA]
 user_role: use-bless
@@ -109,6 +110,7 @@ def test_load_config():
             'update_script': 'autoupdate.sh',
             'user_session_length': 3600,
             'usebless_role_session_length': 3600, # comes from BlessConfig.DEFAULT_CONFIG
+            'update_sshagent': False
         }
     }
 
@@ -122,6 +124,8 @@ def test_get_region_alias_from_aws_region(bless_config_test):
 def test_get_configs(bless_config_test):
     client_config = bless_config_test.get_client_config()
     assert 'domain_regex' in client_config
+    assert bool(client_config['update_sshagent']) is False
+    assert type(client_config['update_sshagent']).__name__ == 'bool'
     lambda_config = bless_config_test.get_lambda_config()
     assert 'functionname' in lambda_config
     aws_config = bless_config_test.get_aws_config()


### PR DESCRIPTION
This change allows users to disable the blessclient from automatically adding keys into the running ssh-agent by specifying a new blessclient.cfg config entry. 

The motivation behind this change is to allow users to optionally disable the bless client from adding entries into the running ssh-agent in order to avoid unexpected issues from having too many keys loaded. For example, if the bless client is called with different identity file names, it will continue appending keys to the ssh-agent. Although there is no effective limit on the number of keys you can add to the running ssh-agent, there is an unintended side-effect to having a lot of keys loaded. If the user tries to a new ssh connection without specifying the `IdentitiesOnly` ssh_config option, each key in the ssh-agent will be sent to the server for authentication, even if an identify file is explicitly defined using the ssh `-i` flag. Given that most servers reject connections after 3 - 6 authentication attempts, a user that unwillingly has multiple keys added to their ssh-agent will run into 'Authentication failed' errors when trying to establish new connections.