### PR TITLE
Enable safe import of tokengui

### DIFF
--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -20,7 +20,13 @@ import json
 from random import randint
 
 import awsmfautils
-import tokengui
+
+ENABLE_GUI=True
+try:
+    import tokengui
+except ImportError:
+    ENABLE_GUI=False
+
 from bless_aws import BlessAWS
 from bless_cache import BlessCache
 from user_ip import UserIP
@@ -202,7 +208,7 @@ def get_mfa_token_gui(message):
 
 def get_mfa_token(showgui, message):
     mfa_token = None
-    if showgui:
+    if showgui and ENABLE_GUI:
         mfa_token = get_mfa_token_gui(message)
     else:
         mfa_token = get_mfa_token_cli()


### PR DESCRIPTION
Importing `tokengui` can blow up:

```
Traceback (most recent call last):
  File "/home/myoung/.blessclient/blessclient.run", line 11, in <module>
    load_entry_point('blessclient', 'console_scripts', 'blessclient')()
  File "/home/myoung/.blessclient/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 570, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/myoung/.blessclient/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2755, in load_entry_point
    return ep.load()
  File "/home/myoung/.blessclient/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2409, in load
    return self.resolve()
  File "/home/myoung/.blessclient/venv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2415, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/myoung/.blessclient/blessclient/client.py", line 23, in <module>
    import tokengui
  File "/home/myoung/.blessclient/blessclient/tokengui.py", line 3, in <module>
    from Tkinter import Tk, Label, Entry, Button, ACTIVE, W, mainloop
  File "/home/myoung/.pyenv/versions/2.7.13/lib/python2.7/lib-tk/Tkinter.py", line 39, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
ImportError: No module named _tkinter

```