### PR TITLE
Fix blessclient focus using Applescript command

### DIFF
--- a/blessclient/tokengui.py
+++ b/blessclient/tokengui.py
@@ -32,19 +32,10 @@ class TokenInputGUI(object):
         self.master.attributes('-topmost', True)
         self.master.focus_force()
         self.e1.focus_set()
-        if platform.system() == 'Darwin':
-            try:
-                from Cocoa import (
-                    NSRunningApplication,
-                    NSApplicationActivateIgnoringOtherApps
-                )
 
-                app = NSRunningApplication.runningApplicationWithProcessIdentifier_(
-                    os.getpid()
-                )
-                app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps)
-            except ImportError:
-                pass
+        if platform.system() == 'Darwin':
+            # Hack to get the GUI dialog focused in OSX
+            os.system('/usr/bin/osascript -e \'tell app "Finder" to set frontmost of process "python" to true\'')
 
         mainloop()
 


### PR DESCRIPTION
**Issue**
On OSX, when the Token GUI is presented it is not active in Finder, so you have to switch tabs to it. I often accidentally type my 2-factor into Terminal.

**Root Cause**
`from Cocoa import *` raises an `ImportError`

**Fix**
Use Applescript to set the focus on the new dialog

![jan-23-2018 10-31-54](https://user-images.githubusercontent.com/220799/35293659-39702d5c-0029-11e8-806d-15a058c9aaec.gif)