### PR TITLE
Restore python3 support in blessclient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 sudo: false
 language: python
-
 matrix:
-  include:
-    - python: "2.7"
-
-install:
-  - make develop
-
-script:
-  - make test
+    include:
+        -   env: TOXENV=py36
+            python: 3.6
+    include:
+        -   env: TOXENV=py27
+            python: 2.7
+install: pip install tox
+script: tox
+cache:
+    directories:
+        - $HOME/.cache/pip

--- a/blessclient/bless_aws.py
+++ b/blessclient/bless_aws.py
@@ -40,7 +40,7 @@ class BlessAWS(object):
                 try:
                     self.iam = boto3.client('iam')
                     break
-                except DataNotFoundError as e:
+                except DataNotFoundError:
                     logging.exception('DataNotFoundError when trying to get the iam client.')
                     t = self.retry_policy(attempt)
                     if t is None:

--- a/blessclient/bless_cache.py
+++ b/blessclient/bless_cache.py
@@ -44,7 +44,7 @@ class BlessCache(object):
             with open(cache_file_path, 'r') as cache:
                 try:
                     self.cache = json.load(cache)
-                except:
+                except Exception:
                     logging.error("Corrupted cache, using empty cache")
         logging.debug("Cache loaded: {}".format(self.cache))
 

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -20,8 +20,6 @@ import json
 import hvac
 import getpass
 
-from random import randint
-
 import six
 
 from . import awsmfautils
@@ -470,8 +468,8 @@ def get_cached_auth_token(bless_cache):
 
 
 def get_credentials():
-    print "Enter Vault username:"
-    username = raw_input()
+    print("Enter Vault username:")
+    username = six.moves.input()
     password = getpass.getpass(prompt="Password (will be hidden):")
     return username, password
 
@@ -690,7 +688,7 @@ def bless(region, nocache, showgui, hostname, bless_config):
                 role_creds = get_blessrole_credentials(
                     aws.iam_client(), None, bless_config, bless_cache)
                 logging.debug("Default creds used to assume role use-bless")
-            except:
+            except Exception:
                 pass  # TODO
 
         if role_creds is None:
@@ -709,7 +707,7 @@ def bless(region, nocache, showgui, hostname, bless_config):
                     role_creds = get_blessrole_credentials(
                         aws.iam_client(), creds, bless_config, bless_cache)
                     logging.debug("Assumed role use-bless using cached creds")
-            except:
+            except Exception:
                 pass
 
     if role_creds is None:
@@ -810,7 +808,7 @@ def bless(region, nocache, showgui, hostname, bless_config):
     else:
         logging.info(
             "Skipping loading identity into the running ssh-agent "
-            'because this was disabled in the blessclient config.' )
+            'because this was disabled in the blessclient config.')
 
     bless_cache.set('certip', my_ip)
     bless_cache.save()

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -95,7 +95,7 @@ def get_regions(region, bless_config):
         List of regions
     """
     regions = []
-    aws_regions = tuple(bless_config.get('REGION_ALIAS').values())
+    aws_regions = tuple(sorted(bless_config.get('REGION_ALIAS').values()))
     try:
         ndx = aws_regions.index(region)
     except ValueError:

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -251,7 +251,7 @@ def get_kmsauth_token(creds, config, username, cache):
             config['awsregion'],
             aws_creds=creds,
             token_lifetime=60
-        ).get_token()
+        ).get_token().decode('US-ASCII')
     except kmsauth.ServiceConnectionError:
         logging.debug("Network failure for kmsauth")
         raise LambdaInvocationException('Connection error getting kmsauth token.')
@@ -352,7 +352,7 @@ def save_cached_creds(token_data, bless_config):
 def ssh_agent_remove_bless(identity_file):
     DEVNULL = open(os.devnull, 'w')
     try:
-        current = subprocess.check_output(['ssh-add', '-l'])
+        current = subprocess.check_output(['ssh-add', '-l']).decode('UTF-8')
         match = re.search(re.escape(identity_file), current)
         if match:
             subprocess.check_call(
@@ -365,7 +365,7 @@ def ssh_agent_remove_bless(identity_file):
 def ssh_agent_add_bless(identity_file):
     DEVNULL = open(os.devnull, 'w')
     subprocess.check_call(['ssh-add', identity_file], stderr=DEVNULL)
-    current = subprocess.check_output(['ssh-add', '-l'])
+    current = subprocess.check_output(['ssh-add', '-l']).decode('UTF-8')
     if not re.search(re.escape(identity_file), current):
         logging.debug("Could not add '{}' to ssh-agent".format(identity_file))
         sys.stderr.write(

--- a/blessclient/user_ip.py
+++ b/blessclient/user_ip.py
@@ -58,7 +58,7 @@ class UserIP(object):
                         if c not in VALID_IP_CHARACTERS:
                             raise ValueError("Public IP response included invalid character '{}'.".format(c))
                     return content
-        except:
+        except Exception:
             logging.debug('Could not refresh public IP from {}'.format(url), exc_info=True)
 
         return None

--- a/blessclient/user_ip.py
+++ b/blessclient/user_ip.py
@@ -53,7 +53,7 @@ class UserIP(object):
         try:
             with contextlib.closing(urlopen(url, timeout=2)) as f:
                 if f.getcode() == 200:
-                    content = f.read().strip()[:40]
+                    content = f.read().decode().strip()[:40]
                     for c in content:
                         if c not in VALID_IP_CHARACTERS:
                             raise ValueError("Public IP response included invalid character '{}'.".format(c))

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ format=pylint
 # The current value is set so that the build doesn't fail. At least we won't
 # make the software more complex.
 # We should target 10. Likewise, 90 for line length.
-max-complexity = 23
+max-complexity = 25
 max-line-length = 126
 exclude = .git,__pycache__,venv,tests/
 ignore = E402, E124, W503

--- a/tests/blessclient/client_test.py
+++ b/tests/blessclient/client_test.py
@@ -92,7 +92,7 @@ def test_clear_kmsauth_token_cache(null_bless_cache):
 
 def test_get_kmsauth_token(mocker, null_bless_cache):
     tokenmock = mocker.MagicMock()
-    tokenmock.get_token.return_value = 'KMSTOKEN'
+    tokenmock.get_token.return_value = b'KMSTOKEN'
     genermock = mocker.patch('kmsauth.KMSTokenGenerator')
     genermock.return_value = tokenmock
     kmsconfig = {'awsregion': 'us-east-1', 'context': {}, 'kmskey': None}
@@ -150,7 +150,7 @@ def test_uncache_creds():
 
 def test_ssh_agent_remove_bless(mocker):
     outputmock = mocker.patch('subprocess.check_output')
-    outputmock.return_value = '4096 SHA256:hwnh3ccCcxVUo6T6htWvHdkCx/UsNklwy2uQuiBaTLQ /Users/foobar/.ssh/blessid (RSA-CERT)'
+    outputmock.return_value = b'4096 SHA256:hwnh3ccCcxVUo6T6htWvHdkCx/UsNklwy2uQuiBaTLQ /Users/foobar/.ssh/blessid (RSA-CERT)'
     callmock = mocker.patch('subprocess.check_call')
     client.ssh_agent_remove_bless('blessid')
     outputmock.assert_called_once()
@@ -159,7 +159,7 @@ def test_ssh_agent_remove_bless(mocker):
 
 def test_ssh_agent_add_bless(mocker):
     outputmock = mocker.patch('subprocess.check_output')
-    outputmock.return_value = '4096 SHA256:hwnh3ccCcxVUo6T6htWvHdkCx/UsNklwy2uQuiBaTLQ /Users/foobar/.ssh/blessid (RSA-CERT)'
+    outputmock.return_value = b'4096 SHA256:hwnh3ccCcxVUo6T6htWvHdkCx/UsNklwy2uQuiBaTLQ /Users/foobar/.ssh/blessid (RSA-CERT)'
     callmock = mocker.patch('subprocess.check_call')
     client.ssh_agent_add_bless('.ssh/blessid')
     outputmock.assert_called_once()
@@ -168,7 +168,7 @@ def test_ssh_agent_add_bless(mocker):
 
 def test_ssh_agent_add_bless_failed(mocker):
     outputmock = mocker.patch('subprocess.check_output')
-    outputmock.return_value = ''
+    outputmock.return_value = b''
     callmock = mocker.patch('subprocess.check_call')
     logmock = mocker.patch('logging.debug')
     writemock = mocker.patch('sys.stderr.write')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+deps = -rrequirements-dev.txt
+commands =
+    pytest {posargs:tests}
+    flake8 blessclient tests setup.py


### PR DESCRIPTION
I did a few things to make this work better and not regress in the future:
- set up [`tox`](https://tox.readthedocs.io/en/latest/) (standard open-source tool for managing virtualenvs and tests)
- fixed the current flake8 errors
- fixed the tests under python3