### PR TITLE
Use expanduser to more reliably get homedir

### DIFF
--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -281,7 +281,7 @@ def setup_logging():
 def get_bless_cache(nocache, bless_config):
     client_config = bless_config.get_client_config()
     cachedir = os.path.join(
-        os.getenv('HOME', os.getcwd()),
+        os.path.expanduser('~'),
         client_config['cache_dir'])
     cachemode = BlessCache.CACHEMODE_RECACHE if nocache else BlessCache.CACHEMODE_ENABLED
     return BlessCache(cachedir, client_config['cache_file'], cachemode)
@@ -653,7 +653,7 @@ def bless(region, nocache, showgui, hostname, bless_config):
     clistring = psutil.Process(os.getppid()).cmdline()
     identity_file = get_idfile_from_cmdline(
         clistring,
-        os.getenv('HOME', os.getcwd()) + '/.ssh/blessid'
+        os.path.expanduser('~/.ssh/blessid'),
     )
     cert_file = identity_file + '-cert.pub'
 


### PR DESCRIPTION
When the current working directory was missing this was crashing with:

```python
Traceback (most recent call last):
  File "/home/asottile/workspace/blessclient/bless", line 11, in <module>
    load_entry_point('blessclient', 'console_scripts', 'blessclient')()
  File "/home/asottile/workspace/blessclient/python-blessclient/blessclient/client.py", line 864, in main
    bless(region, args.nocache, args.gui, args.host, bless_config)
  File "/home/asottile/workspace/blessclient/python-blessclient/blessclient/client.py", line 648, in bless
    bless_cache = get_bless_cache(nocache, bless_config)
  File "/home/asottile/workspace/blessclient/python-blessclient/blessclient/client.py", line 284, in get_bless_cache
    os.getenv('HOME', os.getcwd()),
FileNotFoundError: [Errno 2] No such file or directory
```