### PR TITLE
Support ssh-ed25519 key format

### DIFF
--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -559,7 +559,7 @@ def vault_bless(nocache, bless_config):
         public_key = f.read()
 
     # Only sign public keys in correct format.
-    if public_key[:8] != 'ssh-rsa ':
+    if not public_key.split(' ')[0] in ['ssh-rsa', 'ssh-ed25519']:
         raise Exception(
             'Refusing to bless {}. Probably not an identity file.'.format(identity_file))
 
@@ -595,7 +595,7 @@ def vault_bless(nocache, bless_config):
     logging.debug("Got back cert: {}".format(cert))
 
     # Error handling
-    if cert[:29] != 'ssh-rsa-cert-v01@openssh.com ':
+    if not cert.split(' ')[0] in ['ssh-rsa-cert-v01@openssh.com', 'ssh-ed25519-cert-v01@openssh.com']:
         error_msg = json.loads(cert)
         if ('errorType' in error_msg
             and error_msg['errorType'] == 'KMSAuthValidationError'


### PR DESCRIPTION
Since https://github.com/Netflix/bless/pull/74 got merged and clients 7.8 have problems connecting to servers <7.8:

https://bugzilla.redhat.com/show_bug.cgi?id=1623929
https://bugs.archlinux.org/task/59838
https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/1790963

And that no solution seems to be on the horizon to resolve this backward compatibility issue, now might be the right time to support ed25519 key signing which, fortunately, is not very difficult on the client side.

This PR does not inclue suggesting that ed25519 should the default in README.md as this would be providing advice on the cryptographic methods.