### PR TITLE
Use AWS credentials from environment variables

### DIFF
--- a/blessclient.cfg.sample
+++ b/blessclient.cfg.sample
@@ -63,9 +63,9 @@ update_script: update_blessclient.sh
 # is 3600 seconds (1 hour). The value must be in the range 900-3600.
 
 # update_sshagent: Specifies whether the identity key should be automatically added to the
-running ssh-agent. If this option is set to 'true', the key and the ssh certificate retrieved
-from lambda are added to the agent. If this option is set to 'false', the key is not added
-to the agent. The default is 'true'.
+# running ssh-agent. If this option is set to 'true', the key and the ssh certificate retrieved
+# from lambda are added to the agent. If this option is set to 'false', the key is not added
+# to the agent. The default is 'true'.
 
 [LAMBDA]
 # user_role: IAM Role that the user will assume, in order to run the BLESS Lambda. This

--- a/blessclient.cfg.sample
+++ b/blessclient.cfg.sample
@@ -37,6 +37,10 @@ domain_regex: (.*\.example\.com|.*\.example\.net|\A10\.100(?:\.[0-9]{1,3}){2}\Z)
 cache_dir: .bless/session
 cache_file: bless_cache.json
 
+# Enable this you want to use AWS credentials from environment variables
+# Default false
+use_env_creds: false
+
 # mfa_cache_dir / mfa_cache_file: If you organization has another tool that generates and
 # caches AWS tokens for your users, you can list it here. Blessclient will attempt to use
 # any cached credentials to identify the user, to reduce the number of times the user must

--- a/blessclient/bless_config.py
+++ b/blessclient/bless_config.py
@@ -10,6 +10,7 @@ class BlessConfig(object):
         'update_sshagent': 'true',
         'remote_user': '',
         'ca_backend': 'bless',
+        'use_env_creds': 'false',
     }
 
     def __init__(self):
@@ -42,6 +43,7 @@ class BlessConfig(object):
                 'user_session_length': int(config.get('CLIENT', 'user_session_length')),
                 'usebless_role_session_length': int(config.get('CLIENT', 'usebless_role_session_length')),
                 'update_sshagent': config.getboolean('CLIENT', 'update_sshagent'),
+                'use_env_creds': config.getboolean('CLIENT', 'use_env_creds'),
             },
             'BLESS_CONFIG': {
                 'ca_backend': config.get('MAIN', 'ca_backend'),

--- a/tests/blessclient/bless_config_test.py
+++ b/tests/blessclient/bless_config_test.py
@@ -93,7 +93,8 @@ BASE_EXPECTED_CONF = {
         'update_script': 'autoupdate.sh',
         'user_session_length': 3600,
         'usebless_role_session_length': 3600, # comes from BlessConfig.DEFAULT_CONFIG
-        'update_sshagent': False
+        'update_sshagent': False,
+        'use_env_creds': False # comes from BlessConfig.DEFAULT_CONFIG
     }
 }
 


### PR DESCRIPTION
This commit will allow the use of tools like https://github.com/basefarm/aws-session-tool that store the aws session in environment variables.

Default disabled and can be enabled in the config file. From what I can see all tests are successfully.