### PR TITLE
Ignore W504

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,4 +20,4 @@ format=pylint
 max-complexity = 25
 max-line-length = 126
 exclude = .git,__pycache__,venv,tests/
-ignore = E402, E124, W503
+ignore = E402, E124, W503, W504


### PR DESCRIPTION
This appears to be causing some [CI build failures](https://travis-ci.org/lyft/python-blessclient/builds/467125782) currently, and it [sounds like](https://github.com/openstack/browbeat/commit/90d9c1bc4156025dba2d3ef9c2fbe12e54978363) W504 itself is not fully baked at the moment.  Proposal that we ignore it for now.