### PR TITLE
Use fingerprint during validation instead of identity file

### DIFF
--- a/blessclient/bless_config.py
+++ b/blessclient/bless_config.py
@@ -42,7 +42,7 @@ class BlessConfig(object):
                 'user_session_length': int(config.get('CLIENT', 'user_session_length')),
                 'usebless_role_session_length': int(config.get('CLIENT', 'usebless_role_session_length')),
                 'update_sshagent': config.getboolean('CLIENT', 'update_sshagent'),
-                'enc_assume_role': config.get('CLIENT', 'mfa_assume_role')
+                'enc_assume_role': config.get('CLIENT', 'enc_assume_role')
             },
             'BLESS_CONFIG': {
                 'ca_backend': config.get('MAIN', 'ca_backend'),

--- a/blessclient/bless_config.py
+++ b/blessclient/bless_config.py
@@ -41,8 +41,7 @@ class BlessConfig(object):
                 'update_script': config.get('CLIENT', 'update_script'),
                 'user_session_length': int(config.get('CLIENT', 'user_session_length')),
                 'usebless_role_session_length': int(config.get('CLIENT', 'usebless_role_session_length')),
-                'update_sshagent': config.getboolean('CLIENT', 'update_sshagent'),
-                'enc_assume_role': config.get('CLIENT', 'enc_assume_role')
+                'update_sshagent': config.getboolean('CLIENT', 'update_sshagent')
             },
             'BLESS_CONFIG': {
                 'ca_backend': config.get('MAIN', 'ca_backend'),

--- a/blessclient/bless_config.py
+++ b/blessclient/bless_config.py
@@ -42,6 +42,7 @@ class BlessConfig(object):
                 'user_session_length': int(config.get('CLIENT', 'user_session_length')),
                 'usebless_role_session_length': int(config.get('CLIENT', 'usebless_role_session_length')),
                 'update_sshagent': config.getboolean('CLIENT', 'update_sshagent'),
+                'enc_assume_role': config.get('CLIENT', 'mfa_assume_role')
             },
             'BLESS_CONFIG': {
                 'ca_backend': config.get('MAIN', 'ca_backend'),

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -367,7 +367,10 @@ def ssh_agent_remove_bless(identity_file):
 def ssh_agent_add_bless(identity_file):
     DEVNULL = open(os.devnull, 'w')
     identity_fp = subprocess.check_output(['ssh-keygen','-lf',identity_file]).decode('UTF-8') #Get SHA256 fingerprint of the identity file
-    subprocess.check_call(['ssh-add', identity_file], stderr=DEVNULL)
+    try:
+      subprocess.check_call(['ssh-add', identity_file], stderr=DEVNULL)
+    except Exception:
+        logging.debug("Private Key has password")
     current = subprocess.check_output(['ssh-add', '-l']).decode('UTF-8')
     #if not re.search(re.escape(identity_file), current):
     if not re.search(re.escape(identity_fp), current):

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -731,7 +731,6 @@ def bless(region, nocache, showgui, hostname, bless_config):
             )['Credentials']
 
         except (ClientError, ParamValidationError):
-            print(ClientError.response)
             sys.stderr.write("Incorrect MFA, no certificate issued\n")
             sys.exit(1)
 

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -348,12 +348,14 @@ def save_cached_creds(token_data, bless_config):
     with open(cache_file_path, 'w') as cache:
         json.dump(_token_data, cache)
 
-
 def ssh_agent_remove_bless(identity_file):
     DEVNULL = open(os.devnull, 'w')
+    identity_fp = subprocess.check_output(['ssh-keygen','-lf',identity_file]).decode('UTF-8') #Get SHA256 fingerprint of the identity file
+
     try:
         current = subprocess.check_output(['ssh-add', '-l']).decode('UTF-8')
-        match = re.search(re.escape(identity_file), current)
+        match = re.search(re.escape(identity_fp), current)
+        #match = re.search(re.escape(identity_file), current)
         if match:
             subprocess.check_call(
                 ['ssh-add', '-d', identity_file], stderr=DEVNULL)
@@ -364,9 +366,11 @@ def ssh_agent_remove_bless(identity_file):
 
 def ssh_agent_add_bless(identity_file):
     DEVNULL = open(os.devnull, 'w')
+    identity_fp = subprocess.check_output(['ssh-keygen','-lf',identity_file]).decode('UTF-8') #Get SHA256 fingerprint of the identity file
     subprocess.check_call(['ssh-add', identity_file], stderr=DEVNULL)
     current = subprocess.check_output(['ssh-add', '-l']).decode('UTF-8')
-    if not re.search(re.escape(identity_file), current):
+    #if not re.search(re.escape(identity_file), current):
+    if not re.search(re.escape(identity_fp), current):
         logging.debug("Could not add '{}' to ssh-agent".format(identity_file))
         sys.stderr.write(
             "Couldn't add identity to ssh-agent")

--- a/blessclient/client.py
+++ b/blessclient/client.py
@@ -735,8 +735,15 @@ def bless(region, nocache, showgui, hostname, bless_config):
 
         if creds:
             save_cached_creds(creds, bless_config)
+
+        enc_creds = aws.sts_client().assume_role(
+            RoleArn=bless_config.get_client_config()['enc_assume_role'],
+            RoleSessionName='enc_assume'
+        )['Credentials']
+        
         kmsauth_token = get_kmsauth_token(
-            creds,
+            #creds,
+            enc_creds,
             kmsauth_config,
             username,
             cache=bless_cache


### PR DESCRIPTION
Always throws "Could not add to ssh-agent" error every generation of certificate even though it is successful and it's also not removing the old one. 

Identity_file location (~/.ssh/blessid) is being searched on the the result of ssh-add -i instead of its fingerprint. This changes will use ssh-keygen -lf <identity_file> to get the finger print value of the identity file and use it to check if it's already existing on the ssh agent. 